### PR TITLE
Improve justified text spacing

### DIFF
--- a/src/dom/node.ts
+++ b/src/dom/node.ts
@@ -8,6 +8,7 @@ export interface InlineRun {
   baseline: number;
   text: string;
   width: number;
+  lineWidth: number;
   spaceCount: number;
   targetWidth: number;
 }

--- a/src/layout/strategies/flex.ts
+++ b/src/layout/strategies/flex.ts
@@ -390,7 +390,10 @@ function computePreferredInlineWidth(node: LayoutNode): number | undefined {
   let maxWidth = 0;
   node.walk((desc) => {
     if (desc.inlineRuns && desc.inlineRuns.length > 0) {
-      const localMax = desc.inlineRuns.reduce((max, run) => Math.max(max, run.width), 0);
+      const localMax = desc.inlineRuns.reduce(
+        (max, run) => Math.max(max, run.lineWidth ?? run.width),
+        0,
+      );
       if (localMax > maxWidth) {
         maxWidth = localMax;
       }

--- a/src/layout/utils/inline-formatting.ts
+++ b/src/layout/utils/inline-formatting.ts
@@ -184,6 +184,7 @@ export function layoutInlineFormattingContext(options: InlineLayoutOptions): Inl
         baseline: lineBaseline,
         text: part.item.text,
         width: part.item.width,
+        lineWidth,
         targetWidth: currentAvailableWidth,
         spaceCount: spaceCount,
       };
@@ -328,7 +329,7 @@ export function layoutInlineFormattingContext(options: InlineLayoutOptions): Inl
     const lineCount = runs.reduce((max, run) => Math.max(max, run.lineIndex + 1), 0);
     const lh = resolvedLineHeight(node.style);
     node.box.contentHeight = lineCount * lh;
-    const maxWidth = runs.reduce((max, run) => Math.max(max, run.width), 0);
+    const maxWidth = runs.reduce((max, run) => Math.max(max, run.lineWidth ?? run.width), 0);
     node.box.contentWidth = maxWidth;
     node.box.borderBoxWidth = maxWidth;
     node.box.borderBoxHeight = node.box.contentHeight;

--- a/src/pdf/utils/text-utils.ts
+++ b/src/pdf/utils/text-utils.ts
@@ -27,15 +27,17 @@ export function createTextRuns(node: LayoutNode, color: RGBA | undefined, inheri
     for (const inlineRun of node.inlineRuns) {
       const justify = effectiveTextAlign === "justify" && inlineRun.lineIndex < maxLineIndex;
       let wordSpacing: number | undefined;
+      const targetWidth = inlineRun.targetWidth ?? inlineRun.lineWidth ?? inlineRun.width;
+      const lineWidth = inlineRun.lineWidth ?? inlineRun.width;
       if (justify && inlineRun.spaceCount > 0) {
-        const slack = Math.max(inlineRun.targetWidth - inlineRun.width, 0);
+        const slack = Math.max(targetWidth - lineWidth, 0);
         if (slack > 0) {
           wordSpacing = slack / inlineRun.spaceCount;
         }
       }
       const advanceWidth =
-        wordSpacing !== undefined && inlineRun.spaceCount && inlineRun.targetWidth > 0
-          ? Math.max(inlineRun.targetWidth, inlineRun.width)
+        wordSpacing !== undefined && inlineRun.spaceCount && targetWidth > 0
+          ? Math.max(targetWidth, lineWidth, inlineRun.width)
           : inlineRun.width;
 
       const resolvedShadows = resolveTextShadows(node, defaultColor);

--- a/tests/e2e/justify-inline-fragments.spec.ts
+++ b/tests/e2e/justify-inline-fragments.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "vitest";
+import { prepareHtmlRender } from "../../src/html-to-pdf.js";
+import type { RenderBox, Run } from "../../src/pdf/types.js";
+
+function collectRuns(box: RenderBox): Run[] {
+  const runs: Run[] = [...box.textRuns];
+  for (const child of box.children) {
+    runs.push(...collectRuns(child));
+  }
+  return runs;
+}
+
+test("justified paragraphs distribute slack across fragmented inline content", async () => {
+  const html = `
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <style>
+          body {
+            margin: 0;
+            padding: 0;
+          }
+          p {
+            width: 360px;
+            font-size: 16px;
+            line-height: 24px;
+            text-align: justify;
+          }
+          strong {
+            font-weight: bold;
+          }
+        </style>
+      </head>
+      <body>
+        <p>
+          This paragraph mixes <strong>inline formatting</strong> with regular text so that
+          justification still spreads the remaining space across each line instead of
+          leaving the words clustered on the left.
+        </p>
+      </body>
+    </html>
+  `;
+
+  const { renderTree } = await prepareHtmlRender({
+    html,
+    css: "",
+    viewportWidth: 800,
+    viewportHeight: 600,
+    pageWidth: 595,
+    pageHeight: 842,
+    margins: { top: 0, right: 0, bottom: 0, left: 0 },
+  });
+
+  const runs = collectRuns(renderTree.root).filter((run) => run.text.trim().length > 0 || run.text.includes(" "));
+  expect(runs.length).toBeGreaterThan(1);
+
+  const lines = new Map<number, Run[]>();
+  for (const run of runs) {
+    const baseline = run.lineMatrix.f;
+    const existing = lines.get(baseline) ?? [];
+    existing.push(run);
+    lines.set(baseline, existing);
+  }
+
+  const baselines = Array.from(lines.keys()).sort((a, b) => a - b);
+  expect(baselines.length).toBeGreaterThan(1);
+
+  const firstLine = lines.get(baselines[0]) ?? [];
+  const lastLine = lines.get(baselines[baselines.length - 1]) ?? [];
+
+  expect(firstLine.some((run) => (run.wordSpacing ?? 0) > 0)).toBe(true);
+  expect(lastLine.every((run) => (run.wordSpacing ?? 0) === 0)).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add per-line width tracking to inline runs so justification can distribute slack correctly
- use line widths in PDF text run creation and flex preferred size calculations
- add an end-to-end test covering justified paragraphs with mixed inline formatting

## Testing
- npm test *(fails: existing suite has multiple unrelated failures; run interrupted after repeated errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923bb399240833181d42454c2b39566)